### PR TITLE
Fixing import statements for DuetWebAPI

### DIFF
--- a/TAMV.py
+++ b/TAMV.py
@@ -24,7 +24,7 @@ import imutils
 import datetime
 import time
 import numpy as np
-import DuetWebAPI as DWA
+from DuetWebAPI import DuetWebAPI as DWA
 
 
 if (os.environ.get('SSH_CLIENT')):

--- a/ZTATP.py
+++ b/ZTATP.py
@@ -28,7 +28,7 @@ yp = 340              # Y coord of Z-Probe over flat plate to probe Z. 15x15mm a
 
 toffs = [[0] * 3 for i in range(len(tl))]
 poffs = 0
-import DuetWebAPI as dwa 
+from DuetWebAPI import DuetWebAPI as dwa
 import numpy as np
 
 # Get connected to the printer.  First, see if we are running on the Pi in a Duet3.

--- a/repeatability.py
+++ b/repeatability.py
@@ -24,7 +24,7 @@ import imutils
 import datetime
 import time
 import numpy as np
-import DuetWebAPI as DWA
+from DuetWebAPI import DuetWebAPI as DWA
 
 
 if (os.environ.get('SSH_CLIENT')):


### PR DESCRIPTION
I wasn't able to run TAMV without fixing the import statements in python3 on a raspberry pi4.

changed
```
import DuetWebAPI as DWA
```
to
```
from DuetWebAPI import DuetWebAPI as DWA
```
and that fixed things.